### PR TITLE
Fix deprecations on PHP8

### DIFF
--- a/src/JsonDiffResult.php
+++ b/src/JsonDiffResult.php
@@ -59,21 +59,25 @@ class JsonDiffResult implements ArrayAccess
     }
 
     // Array Access
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->{$offset}) ? $this->{$offset} : null;
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->{$offset}) ? $this->{$offset} : null;
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         throw new CannotChangeDiffResult;
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset) {
          throw new CannotChangeDiffResult;
     }


### PR DESCRIPTION
As PHP attributes are implemented in a BC manner (treated as comments on PHP5/7), the change is fully backwards-compatible.

Tested on PHP 5.6, 7.3 and 8.2.

Fixes #1